### PR TITLE
Fix update dialog order for downloads

### DIFF
--- a/CineCraze Tv/CineCraze Tv/app/src/main/java/com/cinecraze/free/FragmentMainActivity.java
+++ b/CineCraze Tv/CineCraze Tv/app/src/main/java/com/cinecraze/free/FragmentMainActivity.java
@@ -868,8 +868,9 @@ public class FragmentMainActivity extends AppCompatActivity {
                     
                     Log.d("FragmentMainActivity", "Remote manifest version: " + manifest.version);
                     
-                    SharedPreferences sp = getSharedPreferences(PREFS_APP_UPDATE, MODE_PRIVATE);
-                    String lastHandled = sp.getString(KEY_LAST_HANDLED_MANIFEST_VERSION, "");
+                    // Get the last handled version from preferences
+                    SharedPreferences threadSp = getSharedPreferences(PREFS_APP_UPDATE, MODE_PRIVATE);
+                    String lastHandled = threadSp.getString(KEY_LAST_HANDLED_MANIFEST_VERSION, "");
                     
                     Log.d("FragmentMainActivity", "Last handled version: " + lastHandled);
                     Log.d("FragmentMainActivity", "Version comparison: '" + lastHandled + "' vs '" + manifest.version + "'");
@@ -882,7 +883,7 @@ public class FragmentMainActivity extends AppCompatActivity {
                         Log.i("FragmentMainActivity", "*** UPDATE DETECTED *** New manifest version: " + manifest.version + " (was: " + lastHandled + ")");
                         
                         // Mark new version as handled to enforce one-time prompt per version
-                        sp.edit().putString(KEY_LAST_HANDLED_MANIFEST_VERSION, manifest.version).apply();
+                        threadSp.edit().putString(KEY_LAST_HANDLED_MANIFEST_VERSION, manifest.version).apply();
                         
                         runOnUiThread(() -> {
                             Log.i("FragmentMainActivity", "*** LAUNCHING UPDATE ACTIVITY *** for version: " + manifest.version);

--- a/CineCraze Tv/CineCraze Tv/app/src/main/java/com/cinecraze/free/FragmentMainActivity.java
+++ b/CineCraze Tv/CineCraze Tv/app/src/main/java/com/cinecraze/free/FragmentMainActivity.java
@@ -244,8 +244,20 @@ public class FragmentMainActivity extends AppCompatActivity {
         new android.os.Handler().postDelayed(() -> {
             showInterstitialAdIfReady();
         }, 2000); // 2 second delay
-        // Immediately check for manifest update on app open
-        checkManifestAndMaybeForceUpdate();
+        
+        // Only check for manifest updates if this is not a fresh install
+        // For fresh installs, we don't want to show update dialog immediately after download
+        SharedPreferences sp = getSharedPreferences(PREFS_APP_UPDATE, MODE_PRIVATE);
+        String lastHandled = sp.getString(KEY_LAST_HANDLED_MANIFEST_VERSION, "");
+        
+        if (!lastHandled.isEmpty()) {
+            // This is an existing installation, check for updates
+            checkManifestAndMaybeForceUpdate();
+        } else {
+            // This is a fresh install, don't check for updates yet
+            Log.d("FragmentMainActivity", "Fresh install - skipping initial update check");
+        }
+        
         // Ensure manifest watcher is running when main UI is active
         manifestHandler.removeCallbacks(manifestPoller);
         manifestHandler.postDelayed(manifestPoller, MANIFEST_POLL_INTERVAL_MS);


### PR DESCRIPTION
Prioritize download dialog for fresh installs and defer update checks to subsequent app opens.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0c7992b-b5c6-40ed-bab0-77fb2ab95a67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0c7992b-b5c6-40ed-bab0-77fb2ab95a67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

